### PR TITLE
Fix user request

### DIFF
--- a/pypoint/__init__.py
+++ b/pypoint/__init__.py
@@ -124,7 +124,7 @@ class PointSession(OAuth2Session):
 
     def user(self):
         """Update and returns the user data."""
-        return self._request(MINUT_USERS_URL)
+        return self._request(MINUT_USERS_URL + "/" + self._token['user_id'])
 
     def _register_webhook(self, webhook_url, events):
         """Register webhook."""

--- a/pypoint/__init__.py
+++ b/pypoint/__init__.py
@@ -124,7 +124,7 @@ class PointSession(OAuth2Session):
 
     def user(self):
         """Update and returns the user data."""
-        return self._request(MINUT_USERS_URL + "/" + self._token['user_id'])
+        return self._request(MINUT_USERS_URL + "/{}".format(self._token['user_id']))
 
     def _register_webhook(self, webhook_url, events):
         """Register webhook."""


### PR DESCRIPTION
Hi Fredrik!

Dev from Minut here, we recently made a change that requires the userid to be sent to the users endpoint to be more explicit with what is returned. The change was not noticed as we don't use the endpoint without id ourselves, but I noticed it wasn't marked as required in the docs, so I'll update that tomorrow. 
Anyway, this PR fixes the issue, I've tested it with my own homeassistant instance and it looks to be working :) 